### PR TITLE
Update schedule-broken-link-check.yaml

### DIFF
--- a/.github/workflows/schedule-broken-link-check.yaml
+++ b/.github/workflows/schedule-broken-link-check.yaml
@@ -32,7 +32,6 @@
             args: >
               --verbose
               --no-progress
-              --exclude-mail
               './**/*.md'
 
         - name: Find Link Checker Issue


### PR DESCRIPTION
Fixes #189 by removing the deprecated `--exclude-mail` flag