### PR TITLE
Implement fuzzy matching for bot references

### DIFF
--- a/bot/discord/commands/user_mentions.go
+++ b/bot/discord/commands/user_mentions.go
@@ -103,7 +103,7 @@ func DirectedMessageReceive(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 	}
 	if IsBotReferenced(m.Content) {
-		logger.Sugar().Debug("Detected Bot Reference in message from ", m.Author.Username)
+		logger.Sugar().Debug("Detected BloopyBoi in message from ", m.Author.Username)
 		reactn := NoticedReactionPool[rand.Intn(len(NoticedReactionPool))]
 		err := s.MessageReactionAdd(m.ChannelID, m.ID, reactn)
 		if err != nil {

--- a/bot/discord/commands/user_mentions.go
+++ b/bot/discord/commands/user_mentions.go
@@ -3,13 +3,51 @@ package commands
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 
+	"github.com/adrg/strutil/metrics"
 	"github.com/bwmarrin/discordgo"
 	"go.uber.org/zap"
 )
 
-var NoticedReactionPool = []string{"👀","🙊","🙈","🙉","👁️","👄","🫦","✍🏽","🐸","🐢","🥁","🔬","🔭","⁉️","🆒"}
+var (
+	NoticedReactionPool = []string{"👀", "🙊", "🙈", "🙉", "👁️", "👄", "🫦", "✍🏽", "🐸", "🐢", "🥁", "🔬", "🔭", "⁉️", "🆒"}
+
+	botRefRegexes = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bbloopy\s*boi\b`),
+		regexp.MustCompile(`(?i)\bbloop\s*boi\b`),
+		regexp.MustCompile(`(?i)\bthe\s*boi\b`),
+		regexp.MustCompile(`(?i)\bthe\s*bot\b`),
+		regexp.MustCompile(`(?i)\bbloopyboi\b`),
+		regexp.MustCompile(`(?i)\bbloopy\b`),
+	}
+)
+
+// IsBotReferenced checks if the message content refers to the bot, either exactly or fuzzily.
+func IsBotReferenced(content string) bool {
+	// Exact/Phrase matches with word boundaries
+	for _, re := range botRefRegexes {
+		if re.MatchString(content) {
+			return true
+		}
+	}
+
+	// Fuzzy matching for typos
+	oc := metrics.NewOverlapCoefficient()
+	words := strings.Fields(strings.ToLower(content))
+	for _, word := range words {
+		cleanWord := strings.Trim(word, ".,!?;:()[]{}")
+		if len(cleanWord) < 5 {
+			continue // avoid too short words matching fuzzily
+		}
+		// Check against primary name
+		if oc.Compare("bloopyboi", cleanWord) >= 0.8 {
+			return true
+		}
+	}
+	return false
+}
 
 //TODO: Migrate to asynchandlers
 // Listens for messages specifically addressing bot
@@ -64,8 +102,8 @@ func DirectedMessageReceive(s *discordgo.Session, m *discordgo.MessageCreate) {
 			}
 		}
 	}
-	if strings.Contains(strings.ToLower(m.Content), "bloopyboi") {
-		logger.Sugar().Debug("Detected BloopyBoi in message from ", m.Author.Username)
+	if IsBotReferenced(m.Content) {
+		logger.Sugar().Debug("Detected Bot Reference in message from ", m.Author.Username)
 		reactn := NoticedReactionPool[rand.Intn(len(NoticedReactionPool))]
 		err := s.MessageReactionAdd(m.ChannelID, m.ID, reactn)
 		if err != nil {

--- a/bot/discord/commands/user_mentions_test.go
+++ b/bot/discord/commands/user_mentions_test.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsBotReferenced(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "Exact match",
+			content:  "bloopyboi",
+			expected: true,
+		},
+		{
+			name:     "Case insensitive exact match",
+			content:  "BloopyBoi",
+			expected: true,
+		},
+		{
+			name:     "Contains bloopyboi",
+			content:  "hey bloopyboi how are you",
+			expected: true,
+		},
+		{
+			name:     "Bloopy boi with space",
+			content:  "hey bloopy boi",
+			expected: true,
+		},
+		{
+			name:     "Bloopy boi with multiple spaces",
+			content:  "hey bloopy   boi",
+			expected: true,
+		},
+		{
+			name:     "Bloop boi",
+			content:  "bloop boi is here",
+			expected: true,
+		},
+		{
+			name:     "The boi",
+			content:  "referencing the boi",
+			expected: true,
+		},
+		{
+			name:     "The bot",
+			content:  "where is the bot?",
+			expected: true,
+		},
+		{
+			name:     "Bloopy",
+			content:  "hey bloopy!",
+			expected: true,
+		},
+		{
+			name:     "Fuzzy match typo bloopyboii",
+			content:  "bloopyboii is cool",
+			expected: true,
+		},
+		{
+			name:     "Fuzzy match typo bloopyboy",
+			content:  "hey bloopyboy",
+			expected: true,
+		},
+		{
+			name:     "False positive the bottom",
+			content:  "at the bottom of the sea",
+			expected: false,
+		},
+		{
+			name:     "False positive blooming",
+			content:  "the flowers are blooming",
+			expected: false,
+		},
+		{
+			name:     "False positive boil",
+			content:  "water will boil",
+			expected: false,
+		},
+		{
+			name:     "Random message",
+			content:  "hello world",
+			expected: false,
+		},
+		{
+			name:     "Short word no match",
+			content:  "the",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsBotReferenced(tt.content))
+		})
+	}
+}


### PR DESCRIPTION
This PR implements fuzzy matching for references to the bot in messages.
It addresses issue #676 by supporting variations like "bloopy boi", "the bot", "the boi", and handling typos in "bloopyboi" using the Overlap Coefficient metric.
The implementation uses regular expressions with word boundaries to avoid false positives (e.g., matching "the bottom" for "the bot").
Comprehensive tests are included to verify the logic against various positive and negative cases.

---
*PR created automatically by Jules for task [7937232813422130724](https://jules.google.com/task/7937232813422130724) started by @h3mmy*